### PR TITLE
TextArea behaviour when keyboard shown

### DIFF
--- a/OLCore/Classes/Extensions/FormTableViewController+UITextView.swift
+++ b/OLCore/Classes/Extensions/FormTableViewController+UITextView.swift
@@ -10,7 +10,8 @@ import UIKit
 
 extension FormTableViewController: UITextViewDelegate {
     public func textViewDidBeginEditing(_ textView: UITextView) {
-        keyboardWillShow()
+        guard let textArea = textView as? TextArea else { return }
+        scrollToVisibleInput(textArea)
     }
 
     public func textViewDidEndEditing(_ textView: UITextView) {

--- a/OLCore/Classes/ViewControllers/TableViewController/FormTableViewController.swift
+++ b/OLCore/Classes/ViewControllers/TableViewController/FormTableViewController.swift
@@ -79,6 +79,11 @@ open class FormTableViewController: TableViewController {
         guard let row = input.getInputView().getParentCell() else { return }
         contentView.scrollTo(row: row)
     }
+    
+    public func scrollToVisibleInput(_ input: InputProtocol) {
+        guard let row = input.getInputView().getParentCell() else { return }
+        contentView.scrollToVisible(row: row)
+    }
 
     open func validateForm() {
         var firstInvalidInput: InputProtocol?

--- a/OLCore/Classes/Views/TableView/TableView.swift
+++ b/OLCore/Classes/Views/TableView/TableView.swift
@@ -156,6 +156,13 @@ open class TableView: View {
         let indexPath = indexPathOfCell(cell: row)
         tableView.scrollToRow(at: indexPath, at: .top, animated: true)
     }
+    
+    public func scrollToVisible(row: TableViewCell) {
+        guard let superview = row.superview else { return }
+        var visibleRect = row.frame
+        visibleRect = tableView.convert(visibleRect, to: superview)
+        tableView.scrollRectToVisible(visibleRect, animated: true)
+    }
 
     public func dequeueReusableCellWithIdentifier(nibName: String) -> UITableViewCell {
         if let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: nibName) {

--- a/OLCore/Classes/Views/TableView/TableView.swift
+++ b/OLCore/Classes/Views/TableView/TableView.swift
@@ -159,8 +159,7 @@ open class TableView: View {
     
     public func scrollToVisible(row: TableViewCell) {
         guard let superview = row.superview else { return }
-        var visibleRect = row.frame
-        visibleRect = tableView.convert(visibleRect, to: superview)
+        let visibleRect = tableView.convert(row.frame, to: superview)
         tableView.scrollRectToVisible(visibleRect, animated: true)
     }
 

--- a/OLCore/Classes/Views/TextArea/TextArea.swift
+++ b/OLCore/Classes/Views/TextArea/TextArea.swift
@@ -46,6 +46,7 @@ open class TextArea: UITextView {
 
     private func renderPlaceholder(text: String) {
         showingPlaceholder = true
+        autocorrectionType = .no
         textColor = style.placeholderColor
         selectedTextRange = textRange(from: beginningOfDocument, to: beginningOfDocument)
         if self.text != text {
@@ -89,6 +90,7 @@ open class TextArea: UITextView {
             return
         }
         showingPlaceholder = false
+        autocorrectionType = .yes
         self.text = text
         textColor = style.color
         didChange(self)


### PR DESCRIPTION
# JIRA Ticket Link:
https://ndv666.atlassian.net/browse/CN1-978
https://ndv666.atlassian.net/browse/CN1-987

# Issue
- TextArea not scrolling above keyboard when begin editing
- TextArea's placeholder shows autocorrect suggest

# Solution
- Add scroll to visible rect in FormTableView and called it in FormTableView+UITextView delegate extension
- Disable autocorrect when TextArea in placeholder state

# Documentation/References
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.