### PR TITLE
Chore(Button): Support Gradient Button and Expose Button Style to Objc

### DIFF
--- a/OLCore/Classes/Views/Button/Button.swift
+++ b/OLCore/Classes/Views/Button/Button.swift
@@ -18,6 +18,11 @@ open class Button: UIButton {
         }
     }
     public var didPressAction: PressButtonHandler?
+    override open var isEnabled:Bool {
+        didSet {
+            isEnabled ? applyEnabledStyle() : applyDisabledStyle()
+        }
+    }
 
     convenience public init(type buttonType: UIButton.ButtonType) {
         self.init(frame: CGRect.zero)
@@ -91,20 +96,30 @@ open class Button: UIButton {
         highlightFont: UIFont
     ) {
         let attribute = NSMutableAttributedString(string: fullText)
-        let highlightRange = NSRange(location: fullText.count - highlightText.count, length: highlightText.count)
-        attribute.addAttribute(NSAttributedString.Key.font, value: highlightFont, range: highlightRange)
-        attribute.addAttribute(NSAttributedString.Key.foregroundColor, value: style.textColorEnabled, range: NSRange(location: 0, length: fullText.count))
+        let highlightRange = NSRange(
+            location: fullText.count - highlightText.count,
+            length: highlightText.count
+        )
+        attribute.addAttribute(
+            NSAttributedString.Key.font,
+            value: highlightFont,
+            range: highlightRange
+        )
+        attribute.addAttribute(
+            NSAttributedString.Key.foregroundColor,
+            value: style.textColorEnabled,
+            range: NSRange(location: 0, length: fullText.count)
+        )
         setAttributedTitle(attribute, for: .normal)
-    }
-
-    public func setEnabled(_ enabled: Bool = true) {
-        isEnabled = enabled
-        isEnabled ? applyEnabledStyle() : applyDisabledStyle()
     }
 
     @objc public func pressButtonHandler(_ sender: UIButton) {
         guard let action = didPressAction else { return }
         action()
+    }
+
+    @objc public func setStyle(_ style: ButtonStyle) {
+        self.style = style
     }
 
     open override func setTitle(_ title: String?, for state: UIControl.State) {

--- a/OLCore/Classes/Views/Button/Styles/ButtonStyle.swift
+++ b/OLCore/Classes/Views/Button/Styles/ButtonStyle.swift
@@ -8,12 +8,15 @@
 
 import UIKit
 
-public protocol ButtonStyle {
+@objc public protocol ButtonStyle {
     var textFont: UIFont { get }
-    var textColor: UIColor { get }
+    var textColorEnabled: UIColor { get }
+    var textColorDisabled: UIColor { get }
     var textAlignment: NSTextAlignment { get }
     var buttonColorEnabled: UIColor { get }
     var buttonColorDisabled: UIColor { get }
+    var buttonGradientColorsEnabled: [UIColor] { get }
+    var buttonGradientColorsDisabled: [UIColor] { get }
     var borderColor: UIColor { get }
     var borderWidth: CGFloat { get }
     var tintColorEnabled: UIColor { get }

--- a/OLCore/Classes/Views/Button/Styles/DefaultButtonStyle.swift
+++ b/OLCore/Classes/Views/Button/Styles/DefaultButtonStyle.swift
@@ -10,10 +10,13 @@ import UIKit
 
 open class DefaultButtonStyle: ButtonStyle {
     open var textFont = UIFont.systemFont(ofSize: UIFont.buttonFontSize)
-    open var textColor = UIColor.blue
+    open var textColorEnabled = UIColor.blue
+    open var textColorDisabled = UIColor.gray
     open var textAlignment = NSTextAlignment.center
     open var buttonColorEnabled = UIColor.clear
     open var buttonColorDisabled = UIColor.clear
+    open var buttonGradientColorsEnabled = [UIColor]()
+    open var buttonGradientColorsDisabled = [UIColor]()
     open var borderColor = UIColor.clear
     open var borderWidth = CGFloat(0)
     open var tintColorEnabled = UIColor.blue

--- a/OLCore/Classes/Views/TextField/TextField.swift
+++ b/OLCore/Classes/Views/TextField/TextField.swift
@@ -153,7 +153,7 @@ open class TextField: UITextField {
     open func setEnabled(_ enabled: Bool = true) {
         isEnabled = enabled
         guard let rightButton = rightButton else { return }
-        rightButton.setEnabled(enabled)
+        rightButton.isEnabled = enabled
     }
 
     open func didBeginEditingHandler(_ textField: UITextField) {
@@ -178,7 +178,8 @@ open class TextField: UITextField {
     }
 
     open func setRightButtonEnabled(_ enabled: Bool) {
-        rightButton?.setEnabled(enabled)
+        guard let rightButton = rightButton else { return }
+        rightButton.isEnabled = enabled
     }
 
     open func shouldChangeCharactersIn(range: NSRange, replacementString string: String) -> Bool {


### PR DESCRIPTION
# JIRA Ticket Link:
None.

# Issue
- Current Button Style is a struct and it can not be exposed to Objc.
- Current Button Style does not support gradient color.

# Solution
- Change Button Style from `struct` into `class`.
- Create `gradientLayer`.

# Documentation/References
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.

# To Do (if WIP)
None
