### PR TITLE
Fix: Handle text after backspace

### DIFF
--- a/OLCore/Classes/Extensions/FormTableViewController+UITextField.swift
+++ b/OLCore/Classes/Extensions/FormTableViewController+UITextField.swift
@@ -39,11 +39,11 @@ extension FormTableViewController: UITextFieldDelegate {
     }
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if string.isBackspace() { return true }
         guard let tf: TextField = textField as? TextField else { return true }
         guard let initialText: String = tf.text else { return true }
         let isValidLength = tf.maxLength == 0 || initialText.count + string.count - range.length <= tf.maxLength
         var result = isValidLength && tf.shouldChangeCharactersIn(range: range, replacementString: string)
+        if !result && string.isBackspace() { return true }
         if !result { return false }
         let cursorLocation = textField.position(
             from: textField.beginningOfDocument,
@@ -73,7 +73,7 @@ extension FormTableViewController: UITextFieldDelegate {
         if result || initialText != tf.text {
             tf.didChange(textField: tf, newValue: updatedText)
         }
-        if let cursorLocation = cursorLocation{
+        if let cursorLocation = cursorLocation {
             tf.selectedTextRange = tf.textRange(from: cursorLocation, to: cursorLocation)
         }
         return result


### PR DESCRIPTION
# JIRA Ticket Link:
https://ndv666.atlassian.net/browse/CN1-1723

# Issue
- When user backspace the text, replacement string func did not called causing wrong dot in textfield

# Solution
- Only return true for backspace when result is false

# Documentation/References (if any)
None.

# Dependencies (if any)
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.

# To Do (if WIP)
* [ ] None
* [X] None