### PR TITLE
Fix : set clip to bounds for background image

### DIFF
--- a/OLCore/Classes/ViewControllers/ViewController/ViewController.swift
+++ b/OLCore/Classes/ViewControllers/ViewController/ViewController.swift
@@ -183,6 +183,7 @@ open class ViewController: UIViewController {
             link: link,
             placeholderImage: image
         )
+        backgroundView.clipsToBounds = true
         if backgroundView.superview == nil {
             view.addSubview(backgroundView)
         }


### PR DESCRIPTION
# JIRA Ticket Link:
None.

# Issue
Background image bigger than device screen, so the image will appear to other pages

# Solution
Set clip to bounds for background image

# Documentation/References (if any)
None.

# Dependencies (if any)
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.

# To Do (if WIP)
* [ ] None
* [X] None
