### PR TITLE
Fix: ContentView background color turns black in iOS11 [WIP]

### DIFF
--- a/OLCore/Classes/Views/TableView/TableView.swift
+++ b/OLCore/Classes/Views/TableView/TableView.swift
@@ -44,6 +44,7 @@ open class TableView: View {
             sender.render()
         }
         delegate?.tableViewDidCommontInit?(self)
+        self.backgroundColor = .clear
     }
 
     private func createTableView() {


### PR DESCRIPTION
# JIRA Ticket Link:
None.

# Issue
ContentView background color turns black in iOS11

# Solution
Set backgroundColor to clear in TableView commonInit

# Documentation/References (if any)
None.

# Dependencies (if any)
None.

# Screenshots (if appropriate)
None.

# Other things that are not related to the JIRA ticket (if any)
None.

# To Do (if WIP)
* [x] Check in turquoise app
* [ ] Check in red app